### PR TITLE
perf: scipy.misc.imresize is repalced by Image.resize

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 from glob import glob
 from urllib.request import urlretrieve
 from tqdm import tqdm
+from PIL import Image
 
 
 class DLProgress(tqdm):
@@ -105,8 +106,8 @@ def gen_batch_function(data_folder, image_shape):
 			for image_file in image_paths[batch_i:batch_i+batch_size]:
 				gt_image_file = label_paths[os.path.basename(image_file)]
 				# Re-size to image_shape
-				image = scipy.misc.imresize(scipy.misc.imread(image_file), image_shape)
-				gt_image = scipy.misc.imresize(scipy.misc.imread(gt_image_file), image_shape)
+				image = np.array(Image.open(image_file).resize(image_shape))
+				gt_image = np.array(Image.open(gt_image_file).resize(image_shape))
 
 				# Create "one-hot-like" labels by class
 				gt_bg = np.all(gt_image == background_color, axis=2)
@@ -132,7 +133,7 @@ def gen_test_output(sess, logits, keep_prob, image_pl, data_folder, image_shape)
 	:return: Output for for each test image
 	"""
 	for image_file in glob(os.path.join(data_folder, 'image_2', '*.png')):
-		image = scipy.misc.imresize(scipy.misc.imread(image_file), image_shape)
+		image = np.arrary(Image.open(image_file).resize(image_shape))
 
 		# Run inference
 		im_softmax = sess.run(


### PR DESCRIPTION
perf: **imresize** is removed in SciPy 1.3.0. and use **Pillow** insted: `numpy.arrary(Image.fromarray(arr).resize())`